### PR TITLE
gh-action: cache vendor/bundle installation

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,9 +46,14 @@ jobs:
         uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
           ruby-version: 2.6
+      - uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
       - name: Install dependencies
         run: |
           gem install bundler
+          bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - name: Run tests
         run: |


### PR DESCRIPTION
ref: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby#caching-bundle-install